### PR TITLE
Use exact subpackage pins

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: "2.4.0"
-  build_number: 0
+  build_number: 1
 
 recipe:
   name: sparrow-packages
@@ -32,7 +32,7 @@ outputs:
             - Library/lib/sparrow.lib
     requirements:
       run_exports:
-        - ${{ pin_subpackage('sparrow', upper_bound='x.x') }}
+        - ${{ pin_subpackage('sparrow', exact=True) }}
       build:
         - ${{ compiler('cxx') }}
         - ${{ stdlib('c') }}
@@ -75,7 +75,7 @@ outputs:
           - ${{ "Library/" if win }}include/sparrow/json_reader/*.hpp
     requirements:
       run_exports:
-        - ${{ pin_subpackage('sparrow', upper_bound='x.x') }}
+        - ${{ pin_subpackage('sparrow', exact=True) }}
       build:
         - ${{ compiler('cxx') }}
         - ${{ stdlib('c') }}
@@ -133,7 +133,7 @@ outputs:
             - Library/debug/share/cmake/sparrow-json-reader/
     requirements:
       run_exports:
-        - ${{ pin_subpackage('sparrow-json-reader', upper_bound='x.x') }}
+        - ${{ pin_subpackage('sparrow-json-reader', exact=True) }}
       build:
         - ${{ compiler('cxx') }}
         - ${{ stdlib('c') }}


### PR DESCRIPTION
This is to prevent situations where:
```
mamba install sparrow-devel==2.3.0
```
installs:
```
sparrow-devel==2.3.0
sparrow==2.3.1
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
